### PR TITLE
Add source account to operations

### DIFF
--- a/scripts/src/app.py
+++ b/scripts/src/app.py
@@ -64,8 +64,7 @@ def migrate():
     builder.add_text_memo(build_memo(main_account.app_id, None))
 
     # Build tx
-    build_migration_transaction(main_account.keypair.public_address,
-                                builder, proxy_address, client_address, old_balance)
+    build_migration_transaction(builder, proxy_address, client_address, old_balance)
     # Grab an available channel:
     with main_account.channel_manager.get_channel() as channel:
         sign_tx(builder, channel, main_account.keypair.secret_seed)
@@ -84,8 +83,7 @@ def migrate():
 
             # Add the memo manually because use the builder directly
             builder.add_text_memo(build_memo(main_account.app_id, None))
-            build_create_transaction(main_account.keypair.public_address,
-                                     builder, proxy_address, client_address, old_balance)
+            build_create_transaction(builder, proxy_address, client_address, old_balance)
             sign_tx(builder, channel, main_account.keypair.secret_seed)
             try:
                 tx_hash = main_account.submit_transaction(builder)

--- a/scripts/src/app.py
+++ b/scripts/src/app.py
@@ -64,7 +64,8 @@ def migrate():
     builder.add_text_memo(build_memo(main_account.app_id, None))
 
     # Build tx
-    build_migration_transaction(builder, proxy_address, client_address, old_balance)
+    build_migration_transaction(main_account.keypair.public_address,
+                                builder, proxy_address, client_address, old_balance)
     # Grab an available channel:
     with main_account.channel_manager.get_channel() as channel:
         sign_tx(builder, channel, main_account.keypair.secret_seed)
@@ -78,7 +79,13 @@ def migrate():
             # We expect most account to be created, so its better to "ask for forgiveness, not for permission"
             # The user's account was not pre-created on the new blockchain
             logger.info(f'Address: {client_address}, was not pre-created, creating now')
-            build_create_transaction(builder, proxy_address, client_address, old_balance)
+            # Get tx builder, fee is 0 since we are whitelisted
+            builder = main_account.get_transaction_builder(0)
+
+            # Add the memo manually because use the builder directly
+            builder.add_text_memo(build_memo(main_account.app_id, None))
+            build_create_transaction(main_account.keypair.public_address,
+                                     builder, proxy_address, client_address, old_balance)
             sign_tx(builder, channel, main_account.keypair.secret_seed)
             try:
                 tx_hash = main_account.submit_transaction(builder)

--- a/scripts/src/helpers.py
+++ b/scripts/src/helpers.py
@@ -36,23 +36,23 @@ def get_old_balance(account_data: AccountData, kin_issuer: str) -> float:
     return old_balance
 
 
-def build_migration_transaction(source: str, builder: Builder, proxy_address: str,
+def build_migration_transaction(builder: Builder, proxy_address: str,
                                 client_address: str, old_balance: float):
     """Builder a transaction that will migrate an account"""
 
     # First we create the proxy account, this will fail if the migration already happened
     builder.append_create_account_op(destination=proxy_address,
                                      starting_balance=str(0),
-                                     source=source)
+                                     source=builder.address)
 
     if old_balance > 0:
         # Next we pay the kin to the client
         builder.append_payment_op(destination=client_address,
                                   amount=str(old_balance),
-                                  source=source)
+                                  source=builder.address)
 
 
-def build_create_transaction(source: str, builder: Builder, proxy_address: str,
+def build_create_transaction(builder: Builder, proxy_address: str,
                              client_address: str, old_balance: float):
     """
     Build a transaction that will create the new account,
@@ -62,12 +62,12 @@ def build_create_transaction(source: str, builder: Builder, proxy_address: str,
     # First we create the proxy account, this will fail if the migration already happened
     builder.append_create_account_op(destination=proxy_address,
                                      starting_balance=str(0),
-                                     source=source)
+                                     source=builder.address)
 
     # Next we create the client's account
     builder.append_create_account_op(destination=client_address,
                                      starting_balance=str(old_balance),
-                                     source=source)
+                                     source=builder.address)
 
 
 def sign_tx(builder: Builder, channel: str, seed: str):

--- a/scripts/src/helpers.py
+++ b/scripts/src/helpers.py
@@ -36,21 +36,23 @@ def get_old_balance(account_data: AccountData, kin_issuer: str) -> float:
     return old_balance
 
 
-def build_migration_transaction(builder: Builder, proxy_address: str,
+def build_migration_transaction(source: str, builder: Builder, proxy_address: str,
                                 client_address: str, old_balance: float):
     """Builder a transaction that will migrate an account"""
 
     # First we create the proxy account, this will fail if the migration already happened
     builder.append_create_account_op(destination=proxy_address,
-                                     starting_balance=str(0))
+                                     starting_balance=str(0),
+                                     source=source)
 
     if old_balance > 0:
         # Next we pay the kin to the client
         builder.append_payment_op(destination=client_address,
-                                  amount=str(old_balance))
+                                  amount=str(old_balance),
+                                  source=source)
 
 
-def build_create_transaction(builder: Builder, proxy_address: str,
+def build_create_transaction(source: str, builder: Builder, proxy_address: str,
                              client_address: str, old_balance: float):
     """
     Build a transaction that will create the new account,
@@ -59,11 +61,13 @@ def build_create_transaction(builder: Builder, proxy_address: str,
 
     # First we create the proxy account, this will fail if the migration already happened
     builder.append_create_account_op(destination=proxy_address,
-                                     starting_balance=str(0))
+                                     starting_balance=str(0),
+                                     source=source)
 
     # Next we create the client's account
     builder.append_create_account_op(destination=client_address,
-                                     starting_balance=str(old_balance))
+                                     starting_balance=str(old_balance),
+                                     source=source)
 
 
 def sign_tx(builder: Builder, channel: str, seed: str):

--- a/scripts/tests/test_helpers.py
+++ b/scripts/tests/test_helpers.py
@@ -49,14 +49,14 @@ def test_build_migration_transaction():
     client_address = 'GC46XF47MU4NUBBSQJ4KZWLZLN37UECP2TI2IQRYLRUBNGMADHKZBFGL'
     proxy_address = 'GB3MH57M5JPLTPNIVW7BFKTMXSX3JJF4BRXK2R2XD7HBPZ5JMQLUDPSY'
 
-    expected_hash = '8d02af84e13b00c59bea65032f0ee151226b8fb7e2ac26d6e2d905d9d8603fce'
+    expected_hash = 'bdd602b552377f84b80ef34dea732be8094ba5eaf3cc45e7f8f22b1a26a32ed1'
     builder = Builder('TEST', '', 0, 'SCOMIY6IHXNIL6ZFTBBYDLU65VONYWI3Y6EN4IDWDP2IIYTCYZBCCE6C')
     build_migration_transaction(builder, proxy_address, client_address, 0)
     # Client had no balance so we didnt need to pay him
     assert len(builder.ops) == 1
     assert builder.hash_hex() == expected_hash
 
-    expected_hash = 'e61259818578fdbbc848b059f0c9356d2f9915b2c3abdbd5a99ee4a28a1881cc'
+    expected_hash = '90034a54d814b781a555d29bb539f38779f43a6143cc1372893490eb325b42fc'
     builder = Builder('TEST', '', 0, 'SCOMIY6IHXNIL6ZFTBBYDLU65VONYWI3Y6EN4IDWDP2IIYTCYZBCCE6C')
     build_migration_transaction(builder, proxy_address, client_address, 1)
     # Client had balance so we need to pay him
@@ -70,7 +70,7 @@ def test_build_create_transaction():
     client_address = 'GC46XF47MU4NUBBSQJ4KZWLZLN37UECP2TI2IQRYLRUBNGMADHKZBFGL'
     proxy_address = 'GB3MH57M5JPLTPNIVW7BFKTMXSX3JJF4BRXK2R2XD7HBPZ5JMQLUDPSY'
 
-    expected_hash = '3fabebf710dd246184c832949abc596da8598b9718bf49f36a5931677ed70a41'
+    expected_hash = '8a38e61f07ef53a910e34e1d9a94402a534c2e1ba57f25f5a153accc63e9d570'
     builder = Builder('TEST', '', 0, 'SCOMIY6IHXNIL6ZFTBBYDLU65VONYWI3Y6EN4IDWDP2IIYTCYZBCCE6C')
     build_create_transaction(builder, proxy_address, client_address, 0)
     assert builder.hash_hex() == expected_hash


### PR DESCRIPTION
Fixes:
1. Creates a new builder instead of using the old one when sending the second tx in the request
2. Adds the source account to the operations since we are using channels.